### PR TITLE
Bind custom ports to local network

### DIFF
--- a/util/Setup/DockerComposeBuilder.cs
+++ b/util/Setup/DockerComposeBuilder.cs
@@ -198,13 +198,13 @@ services:
                 if(HttpPort != default(int))
                 {
                     sw.Write($@"
-      - '{HttpPort}:8080'");
+      - '127.0.0.1:{HttpPort}:8080'");
                 }
 
                 if(HttpsPort != default(int))
                 {
                     sw.Write($@"
-      - '{HttpsPort}:8443'");
+      - '127.0.0.1:{HttpsPort}:8443'");
                 }
 
                 sw.Write($@"


### PR DESCRIPTION
If you run Bitwarden behind a reverse proxy you can still access it via it's public port binding. This fix prevent access to Bitwarden from a public network.

See #325 for more in info.